### PR TITLE
fix zipper

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ const postcss = require('gulp-postcss');
 const concat = require('gulp-concat');
 const uglify = require('gulp-uglify');
 const beeper = require('beeper');
+const zip = require('gulp-zip');
 
 // postcss plugins
 const easyimport = require('postcss-easy-import');


### PR DESCRIPTION
In its current state, `yarn zip` returns `zip is not defined`. This quick PR fixes that issue by bringing in gulp-zip as zip.