### PR TITLE
Show search icon without setting custom config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ A highly functional theme that adapts to the reader's preferences. Let them read
 ```html
 <script>
     var gh_search_key = 'API_KEY';
-    var gh_search_migration = 'v1';
 </script>
 ```
 
@@ -30,12 +29,11 @@ To force update the index, increment the search index migration version like `'v
 
 ## Disable Content Search
 
-When your site has lots of posts, including the post content in the index cache ends up with exceeding the browser local storage quota. In that case, disabling content search is recommended. Also make sure increase the migration version to force update the old index.
+When your site has lots of posts, including the post content in the index cache ends up with exceeding the browser local storage quota. In that case, disabling content search is recommended.
 
 ```html
 <script>
     var gh_search_key = 'API_KEY';
-    var gh_search_migration = 'v2'; // Increased from v1
     var gh_search_content = false; // Disables content search
 </script>
 ```

--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -11,13 +11,11 @@
     {{#if @site.navigation}}
         <nav class="main-nav hidden-xs hidden-sm hidden-md">
             {{navigation}}
-            {{#if @custom.content_api_key_for_search}}
-                <button class="button-icon menu-item-button js-modal" data-modal="search" aria-label="Search">
-                    <svg class="icon">
-                        <use xlink:href="#magnify"></use>
-                    </svg>
-                </button>
-            {{/if}}
+            <button class="button-icon menu-item-button js-modal" data-modal="search" aria-label="Search">
+                <svg class="icon">
+                    <use xlink:href="#magnify"></use>
+                </svg>
+            </button>
         </nav>
 
         <button class="button-icon hidden-lg hidden-xl js-modal" data-modal="search" aria-label="Search">


### PR DESCRIPTION
Hey folks,

This PR follows up on some changes made in https://github.com/TryGhost/Dawn/commit/85b09f4f788a4429349ebc9ea354d6eeca7dd374. Specifically, we show the search icon for folks who don't set the API key in `package.json` and update the README regarding `gh_search_migration`.

When installing the Dawn theme (say, directly from the Ghost admin panel), we can no longer see the magnifying glass icon from the top nav _if we set `gh_search_key` via code injection_. Users now have to set `@custom.content_api_key_for_search` in order for the magnifying glass to render.

(Interestingly enough, on mobile, it still renders fine because there's no conditional check in the small version.)

https://github.com/TryGhost/Dawn/blob/2cddee61d4e488b9d927361e160309f928159ee3/partials/header.hbs#L23-L27

This PR removes the conditional rendering of the magnifying glass since it prevents people from enabling search without some sort of shell/code access (and it's inconsistent with the documentation). We also remove references to `gh_search_migration` in the documentation, since that variable is no longer being used in this theme.