### PR TITLE
Update header.css

### DIFF
--- a/assets/css/site/header.css
+++ b/assets/css/site/header.css
@@ -69,9 +69,6 @@
 .menu-item-more .icon {
     width: 24px;
     height: 24px;
-}
-
-.menu-item-more svg {
     fill: currentColor;
 }
 

--- a/assets/css/site/header.css
+++ b/assets/css/site/header.css
@@ -71,6 +71,10 @@
     height: 24px;
 }
 
+.menu-item-more svg {
+    fill: currentColor;
+}
+
 .menu-item-cta {
     color: var(--brand-color);
 }


### PR DESCRIPTION
Overflow menu icon (...) didn't change color depending on dark/light mode preference. I updated the CSS so that the SVG icon will fill based on the `currentColor`.

Fixes #61 