### PR TITLE
Fixed a bug with subMenu() failing

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -71,8 +71,8 @@ function sticky() {
 
 function subMenu() {
     'use strict';
-    var mainNav = $('.main-nav');
-    var items = mainNav.find('.menu-item');
+    var nav = $('.main-nav');
+    var items = nav.find('.menu-item');
 
     function getSiblings(el, filter) {
         var siblings = [];


### PR DESCRIPTION
When there is no navigation on the site, `subMenu()` call fails and other functions don't get executed. Reverted the code to requesting elements with jQuery.