### PR TITLE
fix: prevent script crash for sites with no main navigation

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -72,6 +72,12 @@ function sticky() {
 function subMenu() {
     'use strict';
     var nav = document.querySelector('.main-nav');
+
+    // For sites that don't have a main navigation, there is nothing to do
+    if (!nav) {
+        return;
+    }
+
     var items = nav.querySelectorAll('.menu-item');
 
     function getSiblings(el, filter) {


### PR DESCRIPTION
Originally reported in https://forum.ghost.org/t/cant-the-dawn-theme-adapt-to-the-new-version/25235/6